### PR TITLE
[FIX] XCode 12: 'SessionDelegate' has different definitions in different modules

### DIFF
--- a/Sources/Helpers/CommunicatorSessionDelegate.swift
+++ b/Sources/Helpers/CommunicatorSessionDelegate.swift
@@ -7,7 +7,9 @@
 
 import WatchConnectivity
 
-/// Serves as the WCSessionDelegate to obfuscate the delegate methods.
+/// Serves as the WCSessionDelegate to obfuscate the delegate methods. Added @objc(...) attribute to update the Obj-C interface in a generated ...-Swift.h file and avoid the names conflict.
+
+@objc(CommunicatorSessionDelegate)
 final class SessionDelegate: NSObject, WCSessionDelegate {
     
     let communicator: Communicator


### PR DESCRIPTION
Added @objc(...) attribute to the `SessionDelegate` class, which will update the Obj-C interface in a generated ...-Swift.h file, to avoid the name conflict with other libraries with a class named `SessionDelegate` (e.g. Alamofire, Kingfisher...)