### PR TITLE
Fixed errors and warnings in Xcode 14.3

### DIFF
--- a/Sources/Helpers/Messages+Internal.swift
+++ b/Sources/Helpers/Messages+Internal.swift
@@ -17,7 +17,7 @@ extension Blob {
     
     func dataRepresentation() -> Data {
         return NSKeyedArchiver.archivedData(withRootObject: ["identifier" : identifier,
-                                                             "content" : content])
+                                                             "content" : content] as [String: Any])
     }
     
 }

--- a/Sources/Helpers/WatchConnectivity+Helpers.swift
+++ b/Sources/Helpers/WatchConnectivity+Helpers.swift
@@ -35,7 +35,7 @@ public extension Reachability {
         }
         #endif
         #if os(watchOS)
-        if #available(watchOSApplicationExtension 6.0, *) {
+        if #available(watchOS 6.0, *) {
             guard session.isCompanionAppInstalled else {
                 self = .notReachable
                 return
@@ -106,7 +106,7 @@ extension PhoneState {
 extension PhoneState.AppState {
     
     init(session: WCSession) {
-        guard #available(watchOSApplicationExtension 6.0, *) else {
+        guard #available(watchOS 6.0, *) else {
             self = .installed
             return
         }


### PR DESCRIPTION
This PR fixes the following errors and warnings in Xcode 14.3:

**iOS:** `Heterogeneous collection literal could only be inferred to '[String : Any]'; add explicit type annotation if this is intentional`

**watchOS:** `'isCompanionAppInstalled' is only available in watchOS 6.0 or newer`