### PR TITLE
[Fix] fix buildError for single-watchOS app target

### DIFF
--- a/Sources/Helpers/CommunicatorSessionDelegate.swift
+++ b/Sources/Helpers/CommunicatorSessionDelegate.swift
@@ -132,7 +132,7 @@ final class SessionDelegate: NSObject, WCSessionDelegate {
     private func endBackgroundTaskIfRequired() {
         #if os(watchOS)
         guard !communicator.hasPendingDataToBeReceived else { return }
-        if #available(watchOSApplicationExtension 4.0, *) {
+        if #available(watchOS 4.0, *) {
             communicator.task?.setTaskCompletedWithSnapshot(true)
         } else {
             communicator.task?.setTaskCompleted()


### PR DESCRIPTION
In Xcode 14 and later, the system no longer divides a watchOS app into two sections; instead, it is integrated into a single watchOS app.

In this scenario, the preprocessor statement "watchOSApplicationExtension" appears to  result in build errors.

<img width="324" alt="스크린샷 2023-12-14 오후 1 48 46" src="https://github.com/KaneCheshire/Communicator/assets/69072471/8d70a291-4da9-4aa5-835b-551a3d20095f">

Consequently, I have substituted "watchOSApplicationExtension" with "watchOS," resolving the build issues for both the WatchKit extension app and the single watchOS app.

I have checked that these changes do not introduce any additional build errors. If deemed appropriate and free from side effects, I kindly request that my pull request be merged, and these adjustments be applied to CocoaPods as soon as possible.